### PR TITLE
Add 'Loop Transmit' setting, repeats transmission of commands indefinitely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+dist/*
+.vscode
+.clang-format
+.clangd
+.editorconfig
+.env
+.ufbt
+.clang-format
+.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "xremote_ir_signal.h": "c",
+        "xremote_transmit.h": "c"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "files.associations": {
-        "xremote_ir_signal.h": "c",
-        "xremote_transmit.h": "c"
-    }
-}

--- a/helpers/xremote_storage.c
+++ b/helpers/xremote_storage.c
@@ -59,6 +59,7 @@ void xremote_save_settings(void* context) {
         fff_file, XREMOTE_SETTINGS_KEY_SAVE_SETTINGS, &app->save_settings, 1);
     flipper_format_write_uint32(fff_file, XREMOTE_SETTINGS_KEY_IR_TIMING, &app->ir_timing, 1);
     flipper_format_write_uint32(fff_file, XREMOTE_SETTINGS_KEY_SG_TIMING, &app->sg_timing, 1);
+    flipper_format_write_uint32(fff_file, XREMOTE_SETTINGS_KEY_LOOPIR, &app->loopir, 1);
 
     if(!flipper_format_rewind(fff_file)) {
         xremote_close_config_file(fff_file);
@@ -112,6 +113,7 @@ void xremote_read_settings(void* context) {
         fff_file, XREMOTE_SETTINGS_KEY_SAVE_SETTINGS, &app->save_settings, 1);
     flipper_format_read_uint32(fff_file, XREMOTE_SETTINGS_KEY_IR_TIMING, &app->ir_timing, 1);
     flipper_format_read_uint32(fff_file, XREMOTE_SETTINGS_KEY_SG_TIMING, &app->sg_timing, 1);
+    flipper_format_read_uint32(fff_file, XREMOTE_SETTINGS_KEY_LOOPIR, &app->loopir, 1);
 
     flipper_format_rewind(fff_file);
 

--- a/helpers/xremote_storage.c
+++ b/helpers/xremote_storage.c
@@ -59,7 +59,7 @@ void xremote_save_settings(void* context) {
         fff_file, XREMOTE_SETTINGS_KEY_SAVE_SETTINGS, &app->save_settings, 1);
     flipper_format_write_uint32(fff_file, XREMOTE_SETTINGS_KEY_IR_TIMING, &app->ir_timing, 1);
     flipper_format_write_uint32(fff_file, XREMOTE_SETTINGS_KEY_SG_TIMING, &app->sg_timing, 1);
-    flipper_format_write_uint32(fff_file, XREMOTE_SETTINGS_KEY_LOOPIR, &app->loopir, 1);
+    flipper_format_write_uint32(fff_file, XREMOTE_SETTINGS_KEY_LOOP_TRANSMIT, &app->loop_transmit, 1);
 
     if(!flipper_format_rewind(fff_file)) {
         xremote_close_config_file(fff_file);
@@ -113,7 +113,7 @@ void xremote_read_settings(void* context) {
         fff_file, XREMOTE_SETTINGS_KEY_SAVE_SETTINGS, &app->save_settings, 1);
     flipper_format_read_uint32(fff_file, XREMOTE_SETTINGS_KEY_IR_TIMING, &app->ir_timing, 1);
     flipper_format_read_uint32(fff_file, XREMOTE_SETTINGS_KEY_SG_TIMING, &app->sg_timing, 1);
-    flipper_format_read_uint32(fff_file, XREMOTE_SETTINGS_KEY_LOOPIR, &app->loopir, 1);
+    flipper_format_read_uint32(fff_file, XREMOTE_SETTINGS_KEY_LOOP_TRANSMIT, &app->loop_transmit, 1);
 
     flipper_format_rewind(fff_file);
 

--- a/helpers/xremote_storage.h
+++ b/helpers/xremote_storage.h
@@ -13,6 +13,7 @@
 #define XREMOTE_SETTINGS_KEY_SAVE_SETTINGS "SaveSettings"
 #define XREMOTE_SETTINGS_KEY_IR_TIMING "IRTiming"
 #define XREMOTE_SETTINGS_KEY_SG_TIMING "SGTiming"
+#define XREMOTE_SETTINGS_KEY_LOOPIR "LoopIR"
 
 void xremote_save_settings(void* context);
 void xremote_read_settings(void* context);

--- a/helpers/xremote_storage.h
+++ b/helpers/xremote_storage.h
@@ -13,7 +13,7 @@
 #define XREMOTE_SETTINGS_KEY_SAVE_SETTINGS "SaveSettings"
 #define XREMOTE_SETTINGS_KEY_IR_TIMING "IRTiming"
 #define XREMOTE_SETTINGS_KEY_SG_TIMING "SGTiming"
-#define XREMOTE_SETTINGS_KEY_LOOPIR "LoopIR"
+#define XREMOTE_SETTINGS_KEY_LOOP_TRANSMIT "LoopTransmit"
 
 void xremote_save_settings(void* context);
 void xremote_read_settings(void* context);

--- a/scenes/xremote_scene_settings.c
+++ b/scenes/xremote_scene_settings.c
@@ -83,7 +83,7 @@ static void xremote_scene_settings_set_loop(VariableItem* item) {
     XRemote* app = variable_item_get_context(item);
     uint8_t index = variable_item_get_current_value_index(item);
     variable_item_set_current_value_text(item, loop_text[index]);
-    app->loopir = loop_value[index];
+    app->loop_transmit = loop_value[index];
 }
 
 static void xremote_scene_settings_set_ir_timing(VariableItem* item) {
@@ -130,15 +130,15 @@ void xremote_scene_settings_on_enter(void* context) {
 
     // LED Effects on/off
     item = variable_item_list_add(
-        app->variable_item_list, "LED FX:", 2, xremote_scene_settings_set_led, app);
+        app->variable_item_list, "LED FX", 2, xremote_scene_settings_set_led, app);
     value_index = value_index_uint32(app->led, led_value, 2);
     variable_item_set_current_value_index(item, value_index);
     variable_item_set_current_value_text(item, led_text[value_index]);
 
     /* NEW: Loop saved command functionality */
     item = variable_item_list_add(
-        app->variable_item_list, "Loop IR", 2, xremote_scene_settings_set_loop, app);
-    value_index = value_index_uint32(app->loopir, loop_value, 2);
+        app->variable_item_list, "Loop Transmit", 2, xremote_scene_settings_set_loop, app);
+    value_index = value_index_uint32(app->loop_transmit, loop_value, 2);
     variable_item_set_current_value_index(item, value_index);
     variable_item_set_current_value_text(item, loop_text[value_index]);
 

--- a/scenes/xremote_scene_settings.c
+++ b/scenes/xremote_scene_settings.c
@@ -33,7 +33,14 @@ const uint32_t led_value[2] = {
     XRemoteLedOff,
     XRemoteLedOn,
 };
-
+const char* const loop_text[2] = {
+    "OFF",
+    "ON",
+};
+const uint32_t loop_value[2] = {
+    XRemoteLoopOff,
+    XRemoteLoopOn,
+};
 const char* const settings_text[2] = {
     "OFF",
     "ON",
@@ -70,6 +77,13 @@ static void xremote_scene_settings_set_save_settings(VariableItem* item) {
     uint8_t index = variable_item_get_current_value_index(item);
     variable_item_set_current_value_text(item, settings_text[index]);
     app->save_settings = settings_value[index];
+}
+
+static void xremote_scene_settings_set_loop(VariableItem* item) {
+    XRemote* app = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, loop_text[index]);
+    app->loopir = loop_value[index];
 }
 
 static void xremote_scene_settings_set_ir_timing(VariableItem* item) {
@@ -120,6 +134,13 @@ void xremote_scene_settings_on_enter(void* context) {
     value_index = value_index_uint32(app->led, led_value, 2);
     variable_item_set_current_value_index(item, value_index);
     variable_item_set_current_value_text(item, led_text[value_index]);
+
+    /* NEW: Loop saved command functionality */
+    item = variable_item_list_add(
+        app->variable_item_list, "Loop IR", 2, xremote_scene_settings_set_loop, app);
+    value_index = value_index_uint32(app->loopir, loop_value, 2);
+    variable_item_set_current_value_index(item, value_index);
+    variable_item_set_current_value_text(item, loop_text[value_index]);
 
     // Save Settings to File
     item = variable_item_list_add(

--- a/scenes/xremote_scene_transmit.c
+++ b/scenes/xremote_scene_transmit.c
@@ -114,43 +114,13 @@ void xremote_scene_transmit_send_signal(void* context, CrossRemoteItem* item) {
     }
 }
 
-void xremote_scene_transmit_run_remote_inner(void* context) {
-    furi_assert(context);
-    XRemote* app = context;
-    CrossRemote* remote = app->cross_remote;
-    size_t item_count = xremote_cross_remote_get_item_count(remote);
-    for(size_t i = 0; i < item_count;) {
-        if(xremote_cross_remote_get_transmitting(remote) == XRemoteTransmittingIdle) {
-            xremote_cross_remote_set_transmitting(remote, XRemoteTransmittingStart);
-            CrossRemoteItem* item = xremote_cross_remote_get_item(remote, i);
-            xremote_scene_transmit_send_signal(app, item);
-            //furi_thread_flags_wait(0, FuriFlagWaitAny, 1000);
-        } else if(xremote_cross_remote_get_transmitting(remote) == XRemoteTransmittingStopSubghz) {
-            i++;
-            app->state_notifications = SubGhzNotificationStateIDLE;
-            app->transmitting = false;
-            subghz_txrx_stop(app->subghz->txrx);
-            xremote_scene_ir_notification_message(app, SubGhzNotificationMessageBlinkStop);
-            xremote_cross_remote_set_transmitting(remote, XRemoteTransmittingIdle);
-            //furi_thread_flags_wait(0, FuriFlagWaitAny, 1000);
-        } else if(xremote_cross_remote_get_transmitting(remote) == XRemoteTransmittingStop) {
-            i++;
-            xremote_cross_remote_set_transmitting(remote, XRemoteTransmittingIdle);
-        }
-    }
-    xremote_scene_ir_notification_message(app, InfraredNotificationMessageBlinkStop);
-
-    scene_manager_previous_scene(app->scene_manager);
-    //xremote_transmit_model_set_name(app->xremote_transmit, xremote_cross_remote_get_name(remote));
-}
-
 void xremote_scene_transmit_run_remote(void* context) {
     furi_assert(context);
     XRemote* app = context;
     CrossRemote* remote = app->cross_remote;
 
     size_t item_count = xremote_cross_remote_get_item_count(remote);
-    if (app->loopir) {
+    if (app->loop_transmit) {
         while (true) {
             for (size_t i = 0; i < item_count;) {
                 if (xremote_cross_remote_get_transmitting(remote) == XRemoteTransmittingIdle) {

--- a/scenes/xremote_scene_transmit.c
+++ b/scenes/xremote_scene_transmit.c
@@ -114,11 +114,10 @@ void xremote_scene_transmit_send_signal(void* context, CrossRemoteItem* item) {
     }
 }
 
-void xremote_scene_transmit_run_remote(void* context) {
+void xremote_scene_transmit_run_remote_inner(void* context) {
     furi_assert(context);
     XRemote* app = context;
     CrossRemote* remote = app->cross_remote;
-
     size_t item_count = xremote_cross_remote_get_item_count(remote);
     for(size_t i = 0; i < item_count;) {
         if(xremote_cross_remote_get_transmitting(remote) == XRemoteTransmittingIdle) {
@@ -143,6 +142,56 @@ void xremote_scene_transmit_run_remote(void* context) {
 
     scene_manager_previous_scene(app->scene_manager);
     //xremote_transmit_model_set_name(app->xremote_transmit, xremote_cross_remote_get_name(remote));
+}
+
+void xremote_scene_transmit_run_remote(void* context) {
+    furi_assert(context);
+    XRemote* app = context;
+    CrossRemote* remote = app->cross_remote;
+
+    size_t item_count = xremote_cross_remote_get_item_count(remote);
+    if (app->loopir) {
+        while (true) {
+            for (size_t i = 0; i < item_count;) {
+                if (xremote_cross_remote_get_transmitting(remote) == XRemoteTransmittingIdle) {
+                    xremote_cross_remote_set_transmitting(remote, XRemoteTransmittingStart);
+                    CrossRemoteItem* item = xremote_cross_remote_get_item(remote, i);
+                    xremote_scene_transmit_send_signal(app, item);
+                } else if (xremote_cross_remote_get_transmitting(remote) == XRemoteTransmittingStopSubghz) {
+                    i++;
+                    app->state_notifications = SubGhzNotificationStateIDLE;
+                    app->transmitting = false;
+                    subghz_txrx_stop(app->subghz->txrx);
+                    xremote_scene_ir_notification_message(app, SubGhzNotificationMessageBlinkStop);
+                    xremote_cross_remote_set_transmitting(remote, XRemoteTransmittingIdle);
+                } else if (xremote_cross_remote_get_transmitting(remote) == XRemoteTransmittingStop) {
+                    i++;
+                    xremote_cross_remote_set_transmitting(remote, XRemoteTransmittingIdle);
+                }
+            }
+        }
+    } else {
+        for (size_t i = 0; i < item_count;) {
+                if (xremote_cross_remote_get_transmitting(remote) == XRemoteTransmittingIdle) {
+                    xremote_cross_remote_set_transmitting(remote, XRemoteTransmittingStart);
+                    CrossRemoteItem* item = xremote_cross_remote_get_item(remote, i);
+                    xremote_scene_transmit_send_signal(app, item);
+                } else if (xremote_cross_remote_get_transmitting(remote) == XRemoteTransmittingStopSubghz) {
+                    i++;
+                    app->state_notifications = SubGhzNotificationStateIDLE;
+                    app->transmitting = false;
+                    subghz_txrx_stop(app->subghz->txrx);
+                    xremote_scene_ir_notification_message(app, SubGhzNotificationMessageBlinkStop);
+                    xremote_cross_remote_set_transmitting(remote, XRemoteTransmittingIdle);
+                } else if (xremote_cross_remote_get_transmitting(remote) == XRemoteTransmittingStop) {
+                    i++;
+                    xremote_cross_remote_set_transmitting(remote, XRemoteTransmittingIdle);
+                }
+            }
+    }
+    xremote_scene_ir_notification_message(app, InfraredNotificationMessageBlinkStop);
+
+    scene_manager_previous_scene(app->scene_manager);
 }
 
 void xremote_scene_transmit_on_enter(void* context) {

--- a/xremote.c
+++ b/xremote.c
@@ -51,6 +51,7 @@ XRemote* xremote_app_alloc() {
     app->sg_timing = 500;
     app->sg_timing_char = "500";
     app->stop_transmit = false;
+    app->loopir = 0;
 
     // Load configs
     xremote_read_settings(app);

--- a/xremote.c
+++ b/xremote.c
@@ -29,7 +29,7 @@ XRemote* xremote_app_alloc() {
 
     //Scene additions
     app->view_dispatcher = view_dispatcher_alloc();
-    
+
     app->scene_manager = scene_manager_alloc(&xremote_scene_handlers, app);
     view_dispatcher_set_event_callback_context(app->view_dispatcher, app);
     view_dispatcher_set_navigation_event_callback(
@@ -51,7 +51,7 @@ XRemote* xremote_app_alloc() {
     app->sg_timing = 500;
     app->sg_timing_char = "500";
     app->stop_transmit = false;
-    app->loopir = 0;
+    app->loop_transmit = 0;
 
     // Load configs
     xremote_read_settings(app);

--- a/xremote.h
+++ b/xremote.h
@@ -42,7 +42,7 @@ typedef struct {
     uint32_t speaker;
     uint32_t led;
     uint32_t save_settings;
-    uint32_t loopir;
+    uint32_t loop_transmit;
     uint32_t edit_item;
     uint32_t ir_timing;
     char* ir_timing_char;

--- a/xremote.h
+++ b/xremote.h
@@ -42,6 +42,7 @@ typedef struct {
     uint32_t speaker;
     uint32_t led;
     uint32_t save_settings;
+    uint32_t loopir;
     uint32_t edit_item;
     uint32_t ir_timing;
     char* ir_timing_char;
@@ -84,6 +85,11 @@ typedef enum {
     XRemoteLedOff,
     XRemoteLedOn,
 } XRemoteLedState;
+
+typedef enum {
+    XRemoteLoopOff,
+    XRemoteLoopOn,
+} XRemoteLoopState;
 
 typedef enum {
     XRemoteSettingsOff,


### PR DESCRIPTION
Pardon my contribution order/unfamiliarity with GitHub commits. I've added a "Loop Transmit" setting which will infinitely transmit saved commands. This can be used for periodically automating transmission, or for sending an array of signals quickly repeatedly.

I only went as far as to make it continue transmitting rather than adding an exit button as well, I'm very fresh with owning a Flipper and I wanted this functionality and I've just been using the "hold the left and back button" trick to restart the Flipper after I'm done with the loop functionality. Please feel free to edit anything, I am not extremely familiar with C but it is functional on my Flipper.