### PR TITLE
Added Set Timing option for Pause items in Edit/Delete menu

### DIFF
--- a/models/cross/xremote_cross_remote.c
+++ b/models/cross/xremote_cross_remote.c
@@ -116,6 +116,16 @@ bool xremote_cross_remote_add_pause(CrossRemote* remote, int time) {
     return true;
 }
 
+void xremote_cross_remote_set_pause_time(CrossRemote* remote, size_t index, int time) {
+    CrossRemoteItem* item = xremote_cross_remote_get_item(remote, index);
+    // Oversized for the compiler's worst-case int range (format-truncation);
+    // at runtime `time` is clamped to <= 3600 (60:00).
+    char name[32];
+    snprintf(name, sizeof(name), CROSS_REMOTE_PAUSE_NAME, time / 60, time % 60);
+    xremote_cross_remote_item_set_name(item, name);
+    xremote_cross_remote_item_set_time(item, time);
+}
+
 bool xremote_cross_remote_add_subghz(CrossRemote* remote, SubGhzRemote* subghz) {
     CrossRemoteItem* item = xremote_cross_remote_item_alloc();
     xremote_cross_remote_item_set_type(item, XRemoteRemoteItemTypeSubGhz);

--- a/models/cross/xremote_cross_remote.h
+++ b/models/cross/xremote_cross_remote.h
@@ -13,6 +13,7 @@ const char* xremote_cross_remote_get_name(CrossRemote* remote);
 void xremote_cross_remote_set_transmitting(CrossRemote* remote, int status);
 int xremote_cross_remote_get_transmitting(CrossRemote* remote);
 bool xremote_cross_remote_add_pause(CrossRemote* remote, int time);
+void xremote_cross_remote_set_pause_time(CrossRemote* remote, size_t index, int time);
 bool xremote_cross_remote_add_ir_item(
     CrossRemote* remote,
     const char* name,

--- a/scenes/xremote_scene_edit_item.c
+++ b/scenes/xremote_scene_edit_item.c
@@ -17,8 +17,8 @@ void xremote_scene_edit_item_on_enter(void* context) {
     submenu_add_item(
         app->editmenu, "Rename", SubmenuIndexRename, xremote_scene_edit_item_submenu_callback, app);
 
-    if(xremote_cross_remote_get_item_type(app->cross_remote, app->edit_item) ==
-       XRemoteRemoteItemTypeInfrared) {
+    int16_t item_type = xremote_cross_remote_get_item_type(app->cross_remote, app->edit_item);
+    if(item_type == XRemoteRemoteItemTypeInfrared || item_type == XRemoteRemoteItemTypePause) {
         submenu_add_item(
             app->editmenu,
             "Set Timing",
@@ -50,7 +50,13 @@ bool xremote_scene_edit_item_on_event(void* context, SceneManagerEvent event) {
             //scene_manager_next_scene(app->scene_manager, XRemoteSceneWip);
             return 0;
         } else if(event.event == SubmenuIndexTiming) {
-            scene_manager_next_scene(app->scene_manager, XRemoteSceneIrTimer);
+            if(xremote_cross_remote_get_item_type(app->cross_remote, app->edit_item) ==
+               XRemoteRemoteItemTypePause) {
+                app->pause_edit_mode = true;
+                scene_manager_next_scene(app->scene_manager, XRemoteScenePauseSet);
+            } else {
+                scene_manager_next_scene(app->scene_manager, XRemoteSceneIrTimer);
+            }
             return 0;
         }
         scene_manager_next_scene(app->scene_manager, XRemoteSceneCreate);

--- a/scenes/xremote_scene_pause_set.c
+++ b/scenes/xremote_scene_pause_set.c
@@ -31,17 +31,24 @@ bool xremote_scene_pause_set_on_event(void* context, SceneManagerEvent event) {
             consumed = true;
             break;
         case XRemoteCustomEventPauseSetBack:
-            if(!scene_manager_search_and_switch_to_previous_scene(
-                   app->scene_manager, XRemoteSceneCreateAdd)) {
+            if(app->pause_edit_mode) {
+                // Editing an existing Pause item's timing: return to the Edit/Delete menu.
+                scene_manager_previous_scene(app->scene_manager);
+            } else if(!scene_manager_search_and_switch_to_previous_scene(
+                          app->scene_manager, XRemoteSceneCreateAdd)) {
                 scene_manager_stop(app->scene_manager);
                 view_dispatcher_stop(app->view_dispatcher);
             }
             consumed = true;
             break;
         case XRemoteCustomEventPauseSetOk:
-            //xremote_cross_remote_add_pause(app->cross_remote, time);
-            scene_manager_search_and_switch_to_previous_scene(
-                app->scene_manager, XRemoteSceneCreate);
+            if(app->pause_edit_mode) {
+                // Editing an existing Pause item's timing: return to the Edit/Delete menu.
+                scene_manager_previous_scene(app->scene_manager);
+            } else {
+                scene_manager_search_and_switch_to_previous_scene(
+                    app->scene_manager, XRemoteSceneCreate);
+            }
             consumed = true;
             break;
         }
@@ -50,5 +57,6 @@ bool xremote_scene_pause_set_on_event(void* context, SceneManagerEvent event) {
 }
 
 void xremote_scene_pause_set_on_exit(void* context) {
-    UNUSED(context);
+    XRemote* app = context;
+    app->pause_edit_mode = false;
 }

--- a/views/xremote_pause_set.c
+++ b/views/xremote_pause_set.c
@@ -11,12 +11,14 @@ typedef struct {
     const char* name;
     int time; // total pause duration in SECONDS (0..XREMOTE_PAUSE_MAX_SECONDS)
     int field; // which field Up/Down edits: minutes or seconds
+    bool edit_mode; // true when editing an existing Pause item's timing instead of adding a new one
 } XRemotePauseSetModel;
 
 static void xremote_pause_set_model_init(XRemotePauseSetModel* const model) {
     model->type = XRemoteRemoteItemTypePause;
     model->time = 1;
     model->field = XREMOTE_PAUSE_FIELD_SECONDS;
+    model->edit_mode = false;
 }
 
 // Adjust the active field by `dir` (+1/-1) steps. Held keys (InputTypeRepeat)
@@ -75,7 +77,7 @@ void xremote_pause_set_draw(Canvas* canvas, XRemotePauseSetModel* model) {
     // Left/Right arrows flank the time to hint at field selection.
     canvas_draw_icon(canvas, 30, 31, &I_ButtonLeft_4x7);
     canvas_draw_icon(canvas, 94, 31, &I_ButtonRight_4x7);
-    elements_button_center(canvas, "Add");
+    elements_button_center(canvas, model->edit_mode ? "Set" : "Add");
 }
 
 bool xremote_pause_set_input(InputEvent* event, void* context) {
@@ -124,7 +126,12 @@ bool xremote_pause_set_input(InputEvent* event, void* context) {
             XRemotePauseSetModel * model,
             {
                 XRemote* app = instance->context;
-                xremote_cross_remote_add_pause(app->cross_remote, model->time);
+                if(model->edit_mode) {
+                    xremote_cross_remote_set_pause_time(
+                        app->cross_remote, app->edit_item, model->time);
+                } else {
+                    xremote_cross_remote_add_pause(app->cross_remote, model->time);
+                }
             },
             true);
 
@@ -159,10 +166,19 @@ XRemotePauseSet* xremote_pause_set_alloc() {
 void xremote_pause_set_enter(void* context) {
     furi_assert(context);
     XRemotePauseSet* instance = (XRemotePauseSet*)context;
+    XRemote* app = instance->context;
     with_view_model(
         instance->view,
         XRemotePauseSetModel * model,
-        { xremote_pause_set_model_init(model); },
+        {
+            xremote_pause_set_model_init(model);
+            if(app->pause_edit_mode) {
+                CrossRemoteItem* item =
+                    xremote_cross_remote_get_item(app->cross_remote, app->edit_item);
+                model->time = (int)xremote_cross_remote_item_get_time(item);
+                model->edit_mode = true;
+            }
+        },
         true);
 }
 

--- a/xremote.c
+++ b/xremote.c
@@ -54,6 +54,7 @@ XRemote* xremote_app_alloc() {
     app->loop_transmit = 0;
     app->transmit_item = 0;
     app->loadFavorite = false;
+    app->pause_edit_mode = false;
 
     // Load configs
     xremote_read_settings(app);
@@ -175,7 +176,7 @@ void xremote_app_free(XRemote* app) {
 
     app->gui = NULL;
     app->notification = NULL;
-    
+
     //Remove whatever is left
     free(app);
 }
@@ -222,7 +223,7 @@ static void xremote_ir_load_settings(XRemote* app) {
 
 int32_t xremote_app(void* p) {
     XRemote* app = xremote_app_alloc();
-    
+
     view_dispatcher_attach_to_gui(app->view_dispatcher, app->gui, ViewDispatcherTypeFullscreen);
 
     furi_hal_power_suppress_charge_enter();

--- a/xremote.h
+++ b/xremote.h
@@ -37,7 +37,7 @@ typedef struct {
     InfraredRemote* ir_remote_buffer;
     InfraredWorker* ir_worker;
     bool ir_is_otg_enabled; /**< Whether OTG power (external 5V) is enabled for IR. */
-    uint32_t ir_tx_pin; 
+    uint32_t ir_tx_pin;
     SubGhzRemote* sg_remote_buffer;
     CrossRemote* cross_remote;
     uint32_t haptic;
@@ -46,6 +46,7 @@ typedef struct {
     uint32_t save_settings;
     uint32_t loop_transmit;
     uint32_t edit_item;
+    bool pause_edit_mode; // true while XRemoteScenePauseSet edits an existing Pause item's timing
     uint32_t ir_timing;
     char* ir_timing_char;
     uint32_t sg_timing;


### PR DESCRIPTION
## Problem

Pause blocks could only be renamed or deleted after creation - their duration was fixed once added via New Command Chain. To change a pause's timing, the only option was  deleting it and adding a new one.

## Solution

The Edit/Delete menu now shows a Set Timing option for Pause items too, reusing the same MM:SS duration editor used when adding a new pause via New Command Chain.

## Changes

 - scenes/xremote_scene_edit_item.c - show "Set Timing" for Pause items (previously Infrared-only); route to the pause duration editor when selected.
 - views/xremote_pause_set.c - editor now supports an edit mode: seeds the field from the item's current time, changes the confirm button label to "Set", and writes the value back to the existing item instead of creating a new one.
 - scenes/xremote_scene_pause_set.c - Ok/Back return to the Edit/Delete menu (instead of the create screen) when editing an existing pause.
 - models/cross/xremote_cross_remote.c/.h - new xremote_cross_remote_set_pause_time() helper, updates both the stored time and the auto-generated "Pause MM:SS" name.
 - xremote.h/.c - new pause_edit_mode flag on XRemote to distinguish "add new pause" from "edit existing pause".
 
 Using Cross Remote daily - really simplifies my workflow. Solid work, much appreciated! 🙏
