### PR TITLE
Added Move Up/Down options for items in Edit/Delete menu

### DIFF
--- a/models/cross/xremote_cross_remote.c
+++ b/models/cross/xremote_cross_remote.c
@@ -141,6 +141,24 @@ void xremote_cross_remote_remove_item(CrossRemote* remote, size_t index) {
     CrossRemoteItemArray_erase(remote->items, index);
 }
 
+static void xremote_cross_remote_swap_items(CrossRemote* remote, size_t index_a, size_t index_b) {
+    CrossRemoteItem** a = CrossRemoteItemArray_get(remote->items, index_a);
+    CrossRemoteItem** b = CrossRemoteItemArray_get(remote->items, index_b);
+    CrossRemoteItem* tmp = *a;
+    *a = *b;
+    *b = tmp;
+}
+
+void xremote_cross_remote_move_item_up(CrossRemote* remote, size_t index) {
+    if(index == 0 || index >= CrossRemoteItemArray_size(remote->items)) return;
+    xremote_cross_remote_swap_items(remote, index, index - 1);
+}
+
+void xremote_cross_remote_move_item_down(CrossRemote* remote, size_t index) {
+    if(index + 1 >= CrossRemoteItemArray_size(remote->items)) return;
+    xremote_cross_remote_swap_items(remote, index, index + 1);
+}
+
 void xremote_cross_remote_rename_item(CrossRemote* remote, size_t index, const char* name) {
     CrossRemoteItem* item = xremote_cross_remote_get_item(remote, index);
     xremote_cross_remote_item_set_name(item, name);

--- a/models/cross/xremote_cross_remote.h
+++ b/models/cross/xremote_cross_remote.h
@@ -20,6 +20,8 @@ bool xremote_cross_remote_add_ir_item(
     uint32_t timing);
 bool xremote_cross_remote_add_subghz(CrossRemote* remote, SubGhzRemote* subghz);
 void xremote_cross_remote_remove_item(CrossRemote* remote, size_t index);
+void xremote_cross_remote_move_item_up(CrossRemote* remote, size_t index);
+void xremote_cross_remote_move_item_down(CrossRemote* remote, size_t index);
 void xremote_cross_remote_rename_item(CrossRemote* remote, size_t index, const char* name);
 size_t xremote_cross_remote_get_item_count(CrossRemote* remote);
 CrossRemoteItem* xremote_cross_remote_get_item(CrossRemote* remote, size_t index);

--- a/scenes/xremote_scene_edit_item.c
+++ b/scenes/xremote_scene_edit_item.c
@@ -5,6 +5,8 @@ enum SubmenuIndexEdit {
     SubmenuIndexRename = 10,
     SubmenuIndexTiming,
     SubmenuIndexDelete,
+    SubmenuIndexMoveUp,
+    SubmenuIndexMoveDown,
 };
 
 void xremote_scene_edit_item_submenu_callback(void* context, uint32_t index) {
@@ -30,6 +32,24 @@ void xremote_scene_edit_item_on_enter(void* context) {
     submenu_add_item(
         app->editmenu, "Delete", SubmenuIndexDelete, xremote_scene_edit_item_submenu_callback, app);
 
+    size_t item_count = xremote_cross_remote_get_item_count(app->cross_remote);
+    if(app->edit_item > 0) {
+        submenu_add_item(
+            app->editmenu,
+            "Move Up",
+            SubmenuIndexMoveUp,
+            xremote_scene_edit_item_submenu_callback,
+            app);
+    }
+    if(app->edit_item + 1 < item_count) {
+        submenu_add_item(
+            app->editmenu,
+            "Move Down",
+            SubmenuIndexMoveDown,
+            xremote_scene_edit_item_submenu_callback,
+            app);
+    }
+
     submenu_set_selected_item(
         app->editmenu, scene_manager_get_scene_state(app->scene_manager, XRemoteSceneMenu));
 
@@ -45,6 +65,10 @@ bool xremote_scene_edit_item_on_event(void* context, SceneManagerEvent event) {
     } else if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == SubmenuIndexDelete) {
             xremote_cross_remote_remove_item(app->cross_remote, app->edit_item);
+        } else if(event.event == SubmenuIndexMoveUp) {
+            xremote_cross_remote_move_item_up(app->cross_remote, app->edit_item);
+        } else if(event.event == SubmenuIndexMoveDown) {
+            xremote_cross_remote_move_item_down(app->cross_remote, app->edit_item);
         } else if(event.event == SubmenuIndexRename) {
             scene_manager_next_scene(app->scene_manager, XRemoteSceneSaveRemoteItem);
             //scene_manager_next_scene(app->scene_manager, XRemoteSceneWip);


### PR DESCRIPTION
## Problem

Once a command (IR/SubGhz/Pause) was added to a chain, its position was fixed. The only way to reorder a chain was to delete items and re-add them in the right order via New Command Chain, which is tedious for anything but trivial edits.

## Solution

The Edit/Delete menu now shows **Move Up** / **Move Down** options for every item. They swap the selected item with its previous/next neighbor in the chain. The topmost item only shows Move Down (nothing above it to swap with), and the bottommost item only shows Move Up - Move Up/Down are hidden rather than disabled when there's nowhere to move.

## Changes

- `models/cross/xremote_cross_remote.c/.h` - new `xremote_cross_remote_move_item_up()` / `xremote_cross_remote_move_item_down()` helpers that swap two items in place (no realloc, just pointer swap).
- `scenes/xremote_scene_edit_item.c` - Edit/Delete menu conditionally adds "Move Up" (if not first) and "Move Down" (if not last) below Rename/Set Timing/Delete; selecting either performs the swap and returns to the command list, same as Delete does.

## Note

I'm splitting this out into its own PR, separate from the [pause timing fix](https://github.com/leedave/flipper-zero-cross-remote/pull/38), since reordering touches the Edit/Delete menu in a way that might not match how the maintainers want this UX to work (e.g. staying in the menu after a move vs. returning to the list, icons vs. text labels, etc.). Happy to rework it based on feedback - just let me know which direction you'd prefer.
